### PR TITLE
Update: Add a pipeline to build kodi-strm and another to run `black`

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,26 @@
+name: Black
+
+on:
+  push:
+    branches-ignore:
+      - "draft/**"
+      - "docs/**"
+  pull_request:
+    types: [ opened, reopened ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.9" ]
+    
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - uses: psf/black@stable

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,7 @@
 name: Black
 
 on:
+  workflow_dispatch:
   push:
     branches-ignore:
       - "draft/**"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Builder
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - "draft/**"
+      - "docs/**"
+  pull_request:
+    types: [ opened, reopened ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.9" ]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set up cache
+      id: setup-cache
+      uses: actions/cache@v3
+      with:
+        path: .venv
+        key: .venv-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+
+    - name: Install Dependencies
+      if: steps.setup-cache.outputs.cache-hit != 'true'
+      run: |
+        pip install --upgrade virtualenv
+        virtualenv .venv
+        source .venv/bin/activate
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt


### PR DESCRIPTION
Resolves #284 

This branch introduces two parallel pipelines that will run on every commit pushed to the project, and every PR that is opened/re-opened.

- **Black**: This parallel pipeline simply runs [`black`][black] on the entire project to verify that the code-base is properly formatted. A failure of this pipeline simply indicates code can be formatted better (or rather, to better match the standards set by `black`)

- **Build**: This pipeline simply builds the entire project — the main intention being this being to ensure dependencies are compatible with each other. As highlighted in #284, until now, there was always a chance that a PR raised by [`@dependabot`][dependabot] to update a dependency broke the project simply because the updated dependency was not compatible with another existing dependency. The only solution for this problem was for me to manually check and update dependencies. 

    This pipeline aims to resolve this issue — the pipeline will build the project for every PR raised by `dependabot`, and in case a dependency is incompatible with the project, this pipeline will simply fail! A failure of this pipeline indicates that the project in it's current state is broken and unusable.

[dependabot]: https://github.com/dependabot
[black]: https://github.com/psf/black